### PR TITLE
Archive PsimagLite and set it read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,29 +40,11 @@ DISCLOSED WOULD NOT INFRINGE PRIVATELY OWNED RIGHTS.
 
 ## Description
 
-PsimagLite is a collection of C++ classes that are common to
- codes for the simulation of strongly correlated electrons.
-PsimagLite is inspired in T.S.'s Psimag software (but PsimagLite is not a fork of Psimag).
+As of November 2025, PsimagLite is integrated into DMRG++.
+Please see https://github.com/g1257/dmrgpp
+for instructions on cloning DMRG++ and compiling PsimagLite.
 
-The reason for PsimagLite is to share code among different applications.
-Applications that depend on PsimagLite are:
-SpinPhononFermion, DMRG++, Lanczos++, FreeFermions, GpusDoneRight, BetheAnsatz
+## Archived
 
-## Code integrity
-
-Hash of the latest commit is also posted at
-https://g1257.github.com/hashes.html
-
-Latest commit should always be signed.
-Keys at https://g1257.github.com/keys.html
-
-## Building
-git clone https://github.com/g1257/PsimagLite
-cd PsimagLite/
-git checkout features
-git pull origin features
-mkdir build
-cd build
-cmake ..
-make -j number_here
+This project is now archived and read-only.
 


### PR DESCRIPTION
This will set PsimagLite to archive, read-only, and it points users to DMRG++ instead.

I will also ff master into features.
